### PR TITLE
added folding constraints to RNAfold calls

### DIFF
--- a/ostir/ostir.py
+++ b/ostir/ostir.py
@@ -101,7 +101,7 @@ def run_ostir(in_seq, start=None, end=None, name=None, aSD=None, threads=1, deci
 
     start_range_1 = [start_loc_1, end_loc_1]
 
-    calcObj = OSTIRFactory(seq, start_range_1, aSD, verbose=verbose)
+    calcObj = OSTIRFactory(seq, start_range_1, constraints = None, aSD, verbose=verbose) #accounts for constraints argument in OSTIRFactory class
     calcObj.threads = threads
     calcObj.decimal_places = decimal_places
     calcObj.name = name

--- a/ostir/ostir.py
+++ b/ostir/ostir.py
@@ -99,9 +99,11 @@ def run_ostir(in_seq, start=None, end=None, name=None, aSD=None, threads=1, deci
             end_loc_1 = start_loc_1
     end_loc_1 = int(end_loc_1)
 
-    start_range_1 = [start_loc_1, end_loc_1]
+    start_range_1 = [start_loc_1, end_loc_1]   
 
-    calcObj = OSTIRFactory(seq, start_range_1, constraints = None, aSD, verbose=verbose) #accounts for constraints argument in OSTIRFactory class
+    constraints = None #set to account for constrains positional argument in OSTIRFactory class
+
+    calcObj = OSTIRFactory(seq, start_range_1, aSD, constraints, verbose=verbose) 
     calcObj.threads = threads
     calcObj.decimal_places = decimal_places
     calcObj.name = name


### PR DESCRIPTION
Hi Jeff and Cameron,

I have added an additional variable to the OSTIRFactory class to best work with my Csr/Rsm biophysical model. I've tested the python module usage by running the code [described here](https://github.com/barricklab/ostir/wiki/Python-Module-Usage) and it runs without error. 

No changes were made such that users of OSTIR would be able to pass along folding constraints. If thats something that would be useful down the line I can modify it such that it works from the command line and within the run_ostir() function. 

I'm happy to go through and talk about any of these changes or to help fix any errors. 
 
Hope you're both doing well,
Alex
